### PR TITLE
Update despawn logic and remove redundant event

### DIFF
--- a/Bots/BotSpawnService.cs
+++ b/Bots/BotSpawnService.cs
@@ -6,6 +6,7 @@ using Donuts.Bots.SpawnCheckProcessor;
 using Donuts.Models;
 using Donuts.Utils;
 using EFT;
+using EFT.AssetsManager;
 using JetBrains.Annotations;
 using SPT.SinglePlayer.Utils.InRaid;
 using System;
@@ -382,12 +383,8 @@ public abstract class BotSpawnService : IBotSpawnService
 		IBotGame botGame = Singleton<IBotGame>.Instance;
 		Singleton<Effects>.Instance.EffectsCommutator.StopBleedingForPlayer(botOwner.GetPlayer);
 		botOwner.Deactivate();
-		botOwner.Dispose();
-		botGame.BotsController.BotDied(botOwner);
-		botGame.BotsController.DestroyInfo(botOwner.GetPlayer);
-		//DestroyImmediate(botOwner.gameObject);
-		Object.Destroy(botOwner.gameObject);
-		//Destroy(botOwner);
+        botGame.BotDespawn(botOwner);
+        AssetPoolObject.ReturnToPool(botOwner.gameObject);
 
 		// Update the cooldown
 		_despawnCooldownTime = Time.time;

--- a/Bots/DonutsRaidManager.cs
+++ b/Bots/DonutsRaidManager.cs
@@ -139,7 +139,7 @@ public class DonutsRaidManager : MonoBehaviourSingleton<DonutsRaidManager>
 	{
 		_eftBotSpawner.OnBotCreated += EftBotSpawner_OnBotCreated;
 		_eftBotSpawner.OnBotRemoved += EftBotSpawner_OnBotRemoved;
-		_eftBotSpawner.OnBotRemoved += ClearBotOwnerData;
+		//_eftBotSpawner.OnBotRemoved += ClearBotOwnerData;
 		foreach (Player player in BotConfigService.GetHumanPlayerList())
 		{
 			if (player.OrNull()?.HealthController?.IsAlive == true)
@@ -208,7 +208,7 @@ public class DonutsRaidManager : MonoBehaviourSingleton<DonutsRaidManager>
 		if (_eftBotSpawner != null)
 		{
 			_eftBotSpawner.OnBotRemoved -= EftBotSpawner_OnBotRemoved;
-			_eftBotSpawner.OnBotRemoved -= ClearBotOwnerData;
+			//_eftBotSpawner.OnBotRemoved -= ClearBotOwnerData;
 			_eftBotSpawner.OnBotCreated -= EftBotSpawner_OnBotCreated;
 		}
 		


### PR DESCRIPTION
This removes some redundant code during `TryDespawnBot` and swaps `Destroy` with the correct method used in EFT. If `Destroy` is used and not `ReturnToPool`, the equipment of the bot might end up not getting destroyed and left floating.

Also commented out `ClearBotOwnerData` as `OnBotRemoved` already calls most of these methods from `BotSpawner.BotDied()`

Tested a few raids and no errors, although SAIN has started spitting errors regarding not being able to add the component to a null `IPlayer`, which I haven't seen before. Unsure what causes it, but I suspect the despawning of bots.